### PR TITLE
Fix text glitch issue & fix items appearing in lock screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ https://gitlab.gnome.org/Teams/Design/os-mockups/-/blob/master/system-status/qui
 ## Notes
 I have only tested it on laptop devices, mobile and desktop might present some visual issues, install it at your own risk.
 
-## TODO
-
-- [ ] Add support to show a submenu with user related actions, such as "Log out", "Switch user", "Lock screen"(?)
-- [ ] Add support to make the Avatar thumbnail larger
-- [ ] Add options to remove system settings toggles to better adapt it to the available space (possibly will be added in [quick-settings-tweaks](https://github.com/qwreey75/quick-settings-tweaks))
 
 ## License
 This program is distributed under the terms of the GNU General Public License, version 3 or later.

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,5 @@
   ],
   "url": "https://github.com/d-go/quick-settings-avatar",
   "uuid": "quick-settings-avatar@d-go",
-  "version": 2
+  "version": 2.2
 }

--- a/prefs.js
+++ b/prefs.js
@@ -26,12 +26,6 @@ function fillPreferencesWindow(window) {
     // Create the preferences page
     const page = new Adw.PreferencesPage();
 
-    // TODO: Future implementation
-    // Behavior Mode group
-    // const modeGroup = new Adw.PreferencesGroup();
-    // modeGroup.set_title('Behavior Mode');
-    // page.add(modeGroup);
-
     const minimalOpt = createRadio({
         title: 'Minimal',
         subtitle: 'Opens the Users settings on click',
@@ -47,9 +41,6 @@ function fillPreferencesWindow(window) {
         settingId: SETTINGS.MODE,
         group: minimalOpt.radio
     });
-
-    // modeGroup.add(minimalOpt.row);
-    // modeGroup.add(popupOpt.row);
 
     // Position group
     const positionGroup = new Adw.PreferencesGroup();

--- a/utils/controls.js
+++ b/utils/controls.js
@@ -50,7 +50,7 @@ function createSlider({ title, subtitle = '', min = 1, max = 100, step = 1, sett
 
     const slider = new Gtk.Scale({
         digits: 0,
-        adjustment: new Gtk.Adjustment({lower: min, upper: max, stepIncrement: step }),
+        adjustment: new Gtk.Adjustment({ lower: min, upper: max, stepIncrement: step }),
         value_pos: Gtk.PositionType.RIGHT,
         hexpand: true,
         halign: Gtk.Align.END


### PR DESCRIPTION
* Fixed https://github.com/d-go/quick-settings-avatar/issues/4 issue
* Fixed an issue where modifying existing "system" items to align them vertically, was causing  "settings" & "lock" items to appear in lock screen