### PR TITLE
add gnome 44 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
   "description": "Display the user avatar in the Quick Settings menu, part of the \"System\" settings",
   "name": "User Avatar In Quick Settings",
   "shell-version": [
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/d-go/quick-settings-avatar",
   "uuid": "quick-settings-avatar@d-go",


### PR DESCRIPTION
* Just needed to update the metadata file, tested in Gnome 44 beta, no issues found, all extension settings working as expected