### PR TITLE
Support for Gnome 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,9 +6,10 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/d-go/quick-settings-avatar",
   "uuid": "quick-settings-avatar@d-go",
-  "version": 8
+  "version": 9
 }


### PR DESCRIPTION
Works fine without a hiccup

<img width="644" height="429" alt="image" src="https://github.com/user-attachments/assets/8b4599e4-2a60-43eb-8b54-e4843008a8ad" />

<img width="392" height="401" alt="image" src="https://github.com/user-attachments/assets/9e802e02-3539-4761-b3f8-0b0ba759aeb9" />